### PR TITLE
WIP | consolidation of fabric operations related methods

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source tools/common.sh
+
 function die
 {
     local message=$1
@@ -52,7 +54,7 @@ concurrency=""
 parallel=0
 contrail_fab_path='/opt/contrail/utils'
 
-if ! options=$(getopt -o VNnfuUsthdC:lLmF:T:c: -l virtual-env,no-virtual-env,no-site-packages,force,update,upload,sanity,parallel,help,debug,config:,logging,logging-config,send-mail,features:,tags:,concurrency:,contrail-fab-path: -- "$@")
+if ! options=$(getopt -o pVNnfuUsthdC:lLmF:T:c: -l prepare,virtual-env,no-virtual-env,no-site-packages,force,update,upload,sanity,parallel,help,debug,config:,logging,logging-config,send-mail,features:,tags:,concurrency:,contrail-fab-path: -- "$@")
 then
     # parse error
     usage
@@ -64,6 +66,7 @@ first_uu=yes
 while [ $# -gt 0 ]; do
   case "$1" in
     -h|--help) usage; exit;;
+    -p|--prepare) prepare; exit;;
     -V|--virtual-env) always_venv=1; never_venv=0;;
     -N|--no-virtual-env) always_venv=0; never_venv=1;;
     -n|--no-site-packages) no_site_packages=1;;
@@ -92,15 +95,7 @@ done
 
 #export SCRIPT_TS=$(date +"%F_%T")
 
-if [ -n "$config_file" ]; then
-    config_file=`readlink -f "$config_file"`
-    export TEST_CONFIG_DIR=`dirname "$config_file"`
-    export TEST_CONFIG_FILE=`basename "$config_file"`
-fi
-
-if [ ! -f "$config_file" ]; then
-    python tools/configure.py $(readlink -f .) -p $contrail_fab_path
-fi
+prepare
 
 if [ $logging -eq 1 ]; then
     if [ ! -f "$logging_config" ]; then

--- a/scripts/neutron/lbaas/test_lbaas.py
+++ b/scripts/neutron/lbaas/test_lbaas.py
@@ -7,8 +7,6 @@ from vn_test import *
 from vm_test import *
 from common.connections import ContrailConnections
 from tcutils.wrappers import preposttest_wrapper
-from tcutils.util import run_fab_cmd_on_node
-
 from common.openstack_libs import neutron_client_exception as NeutronClientException
 
 from common.neutron.lbaas.base import BaseTestLbaas

--- a/scripts/performance/verify.py
+++ b/scripts/performance/verify.py
@@ -12,7 +12,7 @@ from tcutils.parsers.flow_rate_parse import FlowRateParser
 from config import ConfigPerformance
 from fabric.context_managers import settings, hide
 from fabric.operations import put, get, local
-from util import fab_put_file_to_vm, run_fab_cmd_on_node
+from tcutils.util import fab_put_file_to_vm, run_cmd
 from fabric.api import env, run
 from common.servicechain.config import ConfigSvcChain
 
@@ -380,15 +380,19 @@ class PerformanceTest(ConfigPerformance,ConfigSvcChain):
 
         #Run pktgen on VM
         output = ''
-        with hide('everything'):
-            with settings(host_string='%s@%s' % (self.inputs.username,self.vm1_fixture.vm_node_ip),
-                             password=self.inputs.password, warn_only=True,abort_on_prompts= False):
-                cmd = 'chmod 755 /tmp/pktgen'
-                output = run_fab_cmd_on_node(host_string = '%s@%s'%(self.vm1_fixture.vm_username,self.vm1_fixture.local_ip),
-                                            password = self.vm1_fixture.vm_password, cmd = cmd, as_sudo=False)
-                cmd = 'sudo /tmp/pktgen'
-                output = run_fab_cmd_on_node(host_string = '%s@%s'%(self.vm1_fixture.vm_username,self.vm1_fixture.local_ip),
-                                    password = self.vm1_fixture.vm_password, cmd = cmd, as_sudo=False)
+
+        cmd = 'chmod 755 /tmp/pktgen'
+        output = run_cmd(
+            '%s@%s' % (self.vm1_fixture.vm_username,self.vm1_fixture.local_ip),
+            cmd, self.vm1_fixture.vm_password,
+            '%s@%s' % (self.inputs.username,self.vm1_fixture.vm_node_ip),
+            self.inputs.password
+        )
+        cmd = '/tmp/pktgen'
+        output = run_cmd('%s@%s'%(self.vm1_fixture.vm_username,self.vm1_fixture.local_ip),
+                         cmd, self.vm1_fixture.vm_password,
+                         '%s@%s' % (self.inputs.username,self.vm1_fixture.vm_node_ip),
+                         self.inputs.password, with_sudo=True)
 
         #Check flow -l to check the number of flows created.
         with hide('everything'):

--- a/scripts/vm_regression/test_vm.py
+++ b/scripts/vm_regression/test_vm.py
@@ -1372,8 +1372,6 @@ class TestBasicVMVN4(BaseVnVmTest):
         assert vm1_fixture.wait_till_vm_is_up()
         assert vm2_fixture.wait_till_vm_is_up()
 
-        vm1_fixture.put_pub_key_to_vm()
-        vm2_fixture.put_pub_key_to_vm()
         for size in scp_test_file_sizes:
             self.logger.debug("-" * 80)
             self.logger.debug("FILE SIZE = %sB" % size)

--- a/serial_scripts/control_node_scaling/ssh_interactive_commnds.py
+++ b/serial_scripts/control_node_scaling/ssh_interactive_commnds.py
@@ -79,22 +79,22 @@ class remoteCmdExecuter:
 
     def execCmd(self, cmd, username, password, node, local_ip):
         fab_connections.clear()
-        with hide('everything'):
-            with settings(
-                    host_string='%s@%s' % (username, local_ip),
-                    password=password,
-                    warn_only=True, abort_on_prompts=False, debug=True):
-                if 'show' in cmd:
+        if 'show' in cmd:
+            with hide('everything'):
+                with settings(
+                        host_string='%s@%s' % (username, local_ip),
+                        password=password,
+                        warn_only=True, abort_on_prompts=False, debug=True):
                     result = run_netconf_on_node(
                         host_string='%s@%s' % (
                                     username, node),
                         password=password,
                         cmds=cmd, op_format='json')
-                #ssh_conf_file_alternate = "-o UserKnownHostsFile=/dev/null -o strictHostKeyChecking=no"
-                else:
-                    output = run_fab_cmd_on_node(
-                        host_string='%s@%s' % (username, node),
-                        password=password, cmd=cmd, as_sudo=True)
+        else:
+            result = run_cmd(
+                '%s@%s' % (username, node),
+                cmd, password, '%s@%s' % (username, local_ip),
+                password, with_sudo=True)
 
         return result
 

--- a/serial_scripts/neutron/lbaas/test_lbaas.py
+++ b/serial_scripts/neutron/lbaas/test_lbaas.py
@@ -7,7 +7,6 @@ from vn_test import *
 from vm_test import *
 from common.connections import ContrailConnections
 from tcutils.wrappers import preposttest_wrapper
-from tcutils.util import run_fab_cmd_on_node
 from common.openstack_libs import neutron_client_exception as NeutronClientException
 
 from common.neutron.lbaas.base import BaseTestLbaas


### PR DESCRIPTION
Current method - copy ssh private key to remote node1 and then try
to ssh using that key file - is not required, as ssh-agent forwarding
will enable such facility without ssh private keys present in subsequent
machines. You just need private key on test node and no need to copy
private key to anywhere else, just run ssh-agent on test node and run
the command on remote nodes (even between remote nodes with agent
forwarding enabled.

Changed run_tests.sh to call the function prepare to prepare the system,
also added a parameter to do the same in case somebody wanted to run the
tests manually.

Change-Id: I49f1e22abf84fe26f3f79edcdc808079d356f9a4